### PR TITLE
Add util/content module

### DIFF
--- a/src/emitter.test.ts
+++ b/src/emitter.test.ts
@@ -136,6 +136,7 @@ describe("FileSystemAssetEmitter", () => {
 
     await emitter.done();
 
+    assert.strictEqual(stat.mock.callCount(), 1);
     assert.strictEqual(listener.mock.callCount(), 3);
 
     assert.deepStrictEqual(listener.mock.calls[0]?.arguments[0], {

--- a/src/internal/stream-length.ts
+++ b/src/internal/stream-length.ts
@@ -4,7 +4,7 @@ import { IncomingMessage } from "node:http";
 import { Readable } from "node:stream";
 
 export type Fs = {
-  stat(path: string): PromiseLike<Stats>;
+  stat: (path: string) => PromiseLike<Stats>;
 };
 
 export async function streamLength(

--- a/src/util/content.test.ts
+++ b/src/util/content.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert";
+import { Readable } from "node:stream";
+import { text } from "node:stream/consumers";
+import { describe, it } from "node:test";
+import { contentLength, makeContentStream } from "./content.js";
+
+describe("contentLength", () => {
+  it("returns the byte length for a string", async () => {
+    const value = await contentLength("hello world 🙂");
+
+    assert.strictEqual(value, 16);
+  });
+
+  it("returns the correct length for a Buffer", async () => {
+    const value = await contentLength(
+      Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]),
+    );
+
+    assert.strictEqual(value, 6);
+  });
+});
+
+describe("makeContentStream", () => {
+  describe("when input is a string", () => {
+    it("returns a stream with the same content", async () => {
+      const stream = makeContentStream({ content: "hello world!" });
+
+      const data = await text(stream);
+
+      assert.strictEqual(data, "hello world!");
+    });
+
+    it("succeeds if integrity is valid", async () => {
+      const stream = makeContentStream({
+        content: "hello world!",
+        integrity: "sha1-QwzjTQIHJO11oZbfwq1nx3dy0Wk=",
+      });
+
+      const data = await text(stream);
+
+      assert.strictEqual(data, "hello world!");
+    });
+
+    it("throws if integrity is invalid", async () => {
+      const stream = makeContentStream({
+        content: "hello world!",
+        integrity: "sha1-QwzjToZbfwq1nx3dQIHJO11y0Wk=",
+      });
+
+      await assert.rejects(
+        () => text(stream),
+        (err: NodeJS.ErrnoException) => {
+          assert.strictEqual(err.code, "EINTEGRITY");
+          return true;
+        },
+      );
+    });
+  });
+
+  describe("when input is a buffer", () => {
+    it("returns a stream with the same content", async () => {
+      const stream = makeContentStream({
+        content: Buffer.from("hello world!"),
+      });
+
+      const data = await text(stream);
+
+      assert.strictEqual(data, "hello world!");
+    });
+
+    it("succeeds if integrity is valid", async () => {
+      const stream = makeContentStream({
+        content: Buffer.from("hello world!"),
+        integrity: "sha1-QwzjTQIHJO11oZbfwq1nx3dy0Wk=",
+      });
+
+      const data = await text(stream);
+
+      assert.strictEqual(data, "hello world!");
+    });
+
+    it("throws if integrity is invalid", async () => {
+      const stream = makeContentStream({
+        content: Buffer.from("hello world!"),
+        integrity: "sha1-QwzjToZbfwq1nx3dQIHJO11y0Wk=",
+      });
+
+      await assert.rejects(
+        () => text(stream),
+        (err: NodeJS.ErrnoException) => {
+          assert.strictEqual(err.code, "EINTEGRITY");
+          return true;
+        },
+      );
+    });
+  });
+
+  describe("when input is a stream", () => {
+    it("returns a stream with the same content", async () => {
+      const stream = makeContentStream({
+        content: Readable.from("hello world!"),
+      });
+
+      const data = await text(stream);
+
+      assert.strictEqual(data, "hello world!");
+    });
+
+    it("returns the same stream when no integrity is given", async () => {
+      const content = Readable.from("hello world!");
+      const stream = makeContentStream({ content });
+
+      assert.strictEqual(stream, content);
+    });
+
+    it("succeeds if integrity is valid", async () => {
+      const stream = makeContentStream({
+        content: Readable.from("hello world!"),
+        integrity: "sha1-QwzjTQIHJO11oZbfwq1nx3dy0Wk=",
+      });
+
+      const data = await text(stream);
+
+      assert.strictEqual(data, "hello world!");
+    });
+
+    it("throws if integrity is invalid", async () => {
+      const stream = makeContentStream({
+        content: Readable.from("hello world!"),
+        integrity: "sha1-QwzjToZbfwq1nx3dQIHJO11y0Wk=",
+      });
+
+      await assert.rejects(
+        () => text(stream),
+        (err: NodeJS.ErrnoException) => {
+          assert.strictEqual(err.code, "EINTEGRITY");
+          return true;
+        },
+      );
+    });
+  });
+});

--- a/src/util/content.ts
+++ b/src/util/content.ts
@@ -1,0 +1,45 @@
+import { nextTick } from "process";
+import { checkData, integrityStream } from "ssri";
+import { Readable } from "stream";
+import type { ContentLike } from "../builder.js";
+import { streamLength, type Fs } from "../internal/stream-length.js";
+
+export type ContentStreamInput = {
+  content: ContentLike;
+  integrity?: string;
+};
+
+export async function contentLength(
+  content: ContentLike,
+  fs?: Partial<Fs>,
+): Promise<number | undefined> {
+  if (typeof content === "string") {
+    return Buffer.byteLength(content);
+  } else if (Buffer.isBuffer(content)) {
+    return content.byteLength;
+  } else {
+    return await streamLength(content, fs);
+  }
+}
+
+export function makeContentStream(asset: ContentStreamInput): Readable {
+  const { content, integrity } = asset;
+
+  if (typeof content === "string" || Buffer.isBuffer(content)) {
+    const contentStream = Readable.from(content);
+
+    if (integrity) {
+      try {
+        checkData(content, integrity, { error: true });
+      } catch (err: any) {
+        nextTick(() => contentStream.destroy(err));
+      }
+    }
+
+    return contentStream;
+  } else if (integrity) {
+    return content.compose(integrityStream({ integrity }));
+  } else {
+    return content;
+  }
+}


### PR DESCRIPTION
Added utility functions for working with asset content:

- `contentLength`: returns the byte length of a `ContentLike`, if possible
- `makeContentStream`: turns a `ContentLike` into a `Readable`, and checks the integrity if an `integrity` value is provided